### PR TITLE
Update API Paths

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -82,7 +82,32 @@ info:
   title: Organizr
   version: 1.0.0
 paths:
-  /api/board:
+  /api/login:
+    post:
+      description: Authenticates a member with their username and password from a
+        POST, returning a new JWT session token
+      operationId: login
+      parameters:
+      - example: user@email.com
+        in: formData
+        name: username
+        required: true
+        type: string
+        x-go-name: Username
+      - example: password1234
+        in: formData
+        name: password
+        required: true
+        type: string
+        x-go-name: Password
+      responses:
+        "200":
+          $ref: '#/responses/login-response'
+        "400":
+          $ref: '#/responses/error-response'
+      tags:
+      - authentication
+  /api/r/board:
     get:
       description: Retrieves all boards
       operationId: board-retrieve-all
@@ -109,7 +134,7 @@ paths:
         - '[]'
       tags:
       - board
-  /api/board/{Board_GID}:
+  /api/r/board/{Board_GID}:
     delete:
       description: Deletes board by UUID
       operationId: board-delete
@@ -159,9 +184,10 @@ paths:
         type: string
       - description: Title of board
         in: body
-        name: Title
+        name: title
         schema:
           type: string
+        x-go-name: Title
       responses:
         "200":
           $ref: '#/responses/single-board-response'
@@ -172,26 +198,7 @@ paths:
         - '[]'
       tags:
       - board
-  /api/column/{Board_GID}:
-    get:
-      description: Retrieves all columns by parent board UUID
-      operationId: column-retrieve-all
-      parameters:
-      - description: UUID of parent board
-        in: path
-        name: Board_GID
-        required: true
-        type: string
-      responses:
-        "200":
-          $ref: '#/responses/multi-column-response'
-        "400":
-          $ref: '#/responses/error-response'
-      security:
-      - Bearer:
-        - '[]'
-      tags:
-      - column
+  /api/r/column:
     post:
       description: Creates a column in the board specified by UUID
       operationId: column-create
@@ -205,16 +212,11 @@ paths:
         - '[]'
       tags:
       - column
-  /api/column/{Board_GID}/{Column_GID}:
+  /api/r/column/{Column_GID}:
     delete:
       description: Deletes column by parent board and column UUIDs
       operationId: column-delete
       parameters:
-      - description: UUID of parent board
-        in: path
-        name: Board_GID
-        required: true
-        type: string
       - description: UUID of column
         in: path
         name: Column_GID
@@ -234,11 +236,6 @@ paths:
       description: Retrieves column by parent board and column UUIDs
       operationId: column-retrieve-one
       parameters:
-      - description: UUID of parent board
-        in: path
-        name: Board_GID
-        required: true
-        type: string
       - description: UUID of column
         in: path
         name: Column_GID
@@ -259,10 +256,12 @@ paths:
       operationId: column-update
       parameters:
       - description: UUID of parent board
-        in: path
-        name: Board_GID
+        in: body
+        name: board_gid
         required: true
-        type: string
+        schema:
+          type: string
+        x-go-name: Board_GID
       - description: UUID of column
         in: path
         name: Column_GID
@@ -270,9 +269,10 @@ paths:
         type: string
       - description: Title of column
         in: body
-        name: Title
+        name: title
         schema:
           type: string
+        x-go-name: Title
       responses:
         "200":
           $ref: '#/responses/single-column-response'
@@ -283,77 +283,27 @@ paths:
         - '[]'
       tags:
       - column
-  /api/login:
-    post:
-      description: Authenticates a member with their username and password from a
-        POST, returning a new JWT session token
-      operationId: login
-      parameters:
-      - example: user@email.com
-        in: formData
-        name: Username
-        required: true
-        type: string
-      - example: password1234
-        in: formData
-        name: Password
-        required: true
-        type: string
-      responses:
-        "200":
-          $ref: '#/responses/login-response'
-        "400":
-          $ref: '#/responses/error-response'
-      tags:
-      - authentication
-  /api/register:
-    post:
-      description: Registers a new member using the supplied username, email, and
-        password
-      operationId: register
-      parameters:
-      - example: andrew
-        in: formData
-        name: Username
-        required: true
-        type: string
-      - example: user@email.com
-        in: formData
-        name: Email
-        required: true
-        type: string
-      - example: password1234
-        in: formData
-        name: Password
-        required: true
-        type: string
-      responses:
-        "200":
-          description: ""
-        "400":
-          $ref: '#/responses/error-response'
-      tags:
-      - authentication
-  /api/task/{Column_GID}:
+  /api/r/column?board_gid={Board_GID}:
     get:
-      description: Retrieves all tasks by parent column UUID
-      operationId: task-retrieve-all
+      description: Retrieves all columns by parent board UUID
+      operationId: column-retrieve-all
       parameters:
-      - description: UUID of parent column
-        in: path
-        name: Column_GID
+      - description: UUID of parent board
+        in: query
+        name: Board_GID
         required: true
         type: string
       responses:
         "200":
-          $ref: '#/responses/multi-task-response'
+          $ref: '#/responses/multi-column-response'
         "400":
           $ref: '#/responses/error-response'
       security:
       - Bearer:
         - '[]'
       tags:
-      - task
+      - column
+  /api/r/task:
     post:
       description: Creates a task in the column specified by UUID
       operationId: task-create
@@ -367,16 +317,11 @@ paths:
         - '[]'
       tags:
       - task
-  /api/task/{Column_GID}/{Task_GID}:
+  /api/r/task/{Task_GID}:
     delete:
       description: Deletes task by parent column and task UUIDs
       operationId: task-delete
       parameters:
-      - description: UUID of parent column
-        in: path
-        name: Column_GID
-        required: true
-        type: string
       - description: UUID of task
         in: path
         name: Task_GID
@@ -396,11 +341,6 @@ paths:
       description: Retrieves task by parent column and task UUIDs
       operationId: task-retrieve-one
       parameters:
-      - description: UUID of parent column
-        in: path
-        name: Column_GID
-        required: true
-        type: string
       - description: UUID of task
         in: path
         name: Task_GID
@@ -421,10 +361,12 @@ paths:
       operationId: task-update
       parameters:
       - description: UUID of parent column
-        in: path
-        name: Column_GID
+        in: body
+        name: column_gid
         required: true
-        type: string
+        schema:
+          type: string
+        x-go-name: Column_GID
       - description: UUID of task
         in: path
         name: Task_GID
@@ -432,14 +374,16 @@ paths:
         type: string
       - description: Title of task
         in: body
-        name: Title
+        name: title
         schema:
           type: string
+        x-go-name: Title
       - description: Description of task
         in: body
-        name: Description
+        name: description
         schema:
           type: string
+        x-go-name: Description
       responses:
         "200":
           $ref: '#/responses/single-task-response'
@@ -450,6 +394,57 @@ paths:
         - '[]'
       tags:
       - task
+  /api/r/task?column_gid={Column_GID}:
+    get:
+      description: Retrieves all tasks by parent column UUID
+      operationId: task-retrieve-all
+      parameters:
+      - description: UUID of parent column
+        in: query
+        name: Column_GID
+        required: true
+        type: string
+      responses:
+        "200":
+          $ref: '#/responses/multi-task-response'
+        "400":
+          $ref: '#/responses/error-response'
+      security:
+      - Bearer:
+        - '[]'
+      tags:
+      - task
+  /api/register:
+    post:
+      description: Registers a new member using the supplied username, email, and
+        password
+      operationId: register
+      parameters:
+      - example: andrew
+        in: formData
+        name: username
+        required: true
+        type: string
+        x-go-name: Username
+      - example: user@email.com
+        in: formData
+        name: email
+        required: true
+        type: string
+        x-go-name: Email
+      - example: password1234
+        in: formData
+        name: password
+        required: true
+        type: string
+        x-go-name: Password
+      responses:
+        "200":
+          description: ""
+        "400":
+          $ref: '#/responses/error-response'
+      tags:
+      - authentication
 produces:
 - application/json
 responses:

--- a/server/auth/permissions.go
+++ b/server/auth/permissions.go
@@ -24,13 +24,12 @@ func VerifyBoardPermission(memberId int, boardGid string, minPermission int) (bo
 	err = conn.QueryRow(context.Background(),
 		`
 			SELECT EXISTS(
-				SELECT id
+				SELECT board_member.id
 				FROM board_member
-				WHERE member_id = $1
-				AND board_id = (
-					SELECT id FROM board WHERE gid = $2
-				)
-				AND board_permission_id <= $3
+				JOIN board ON (board.id = board_member.board_id)
+				WHERE board_member.member_id = $1
+				AND board.gid = $2
+				AND board_member.board_permission_id <= $3
 			) AS has_permission;
 		`,
 		memberId, boardGid, minPermission,
@@ -53,16 +52,44 @@ func VerifyColumnPermission(memberId int, columnGid string, minPermission int) (
 	err = conn.QueryRow(context.Background(),
 		`
 			SELECT EXISTS (
-				SELECT id
+				SELECT board_member.id
 				FROM board_member
-				WHERE member_id = $1
-				AND board_id = (
-					SELECT board_id FROM task_column WHERE gid = $2
-				)
-				AND board_permission_id <= $3
+				JOIN task_column ON (task_column.board_id = board_member.board_id)
+				WHERE board_member.member_id = $1
+				AND task_column.gid = $2
+				AND board_member.board_permission_id <= $3
 			) AS has_permission;
 		`,
 		memberId, columnGid, minPermission,
+	).Scan(&hasPermission)
+
+	if err != nil {
+		return false, err
+	}
+	return hasPermission, nil
+}
+
+func VerifyTaskPermission(memberId int, taskGid string, minPermission int) (bool, error) {
+	conn, err := pgx.Connect(context.Background(), os.Getenv("PG_URL"))
+	if err != nil {
+		return false, err
+	}
+	defer conn.Close(context.Background())
+
+	hasPermission := false
+	err = conn.QueryRow(context.Background(),
+		`
+			SELECT EXISTS (
+				SELECT board_member.id
+				FROM board_member
+				JOIN task_column ON (task_column.board_id = board_member.board_id)
+				JOIN task ON (task.task_column_id = task_column.id)
+				WHERE board_member.member_id = $1
+				AND task.gid = $2
+				AND board_member.board_permission_id <= $3
+			) AS has_permission;
+		`,
+		memberId, taskGid, minPermission,
 	).Scan(&hasPermission)
 
 	if err != nil {

--- a/server/models/requests.go
+++ b/server/models/requests.go
@@ -5,12 +5,12 @@ type LoginRequest struct {
 	// in: formData
 	// required: true
 	// example: user@email.com
-	Username string `form:"username"`
+	Username string `form:"username" json:"username"`
 
 	// in: formData
 	// required: true
 	// example: password1234
-	Password string `form:"password"`
+	Password string `form:"password" json:"password"`
 }
 
 // swagger:parameters authentication register
@@ -18,17 +18,17 @@ type RegisterRequest struct {
 	// in: formData
 	// required: true
 	// example: andrew
-	Username string `form:"username"`
+	Username string `form:"username" json:"username"`
 
 	// in: formData
 	// required: true
 	// example: user@email.com
-	Email string `form:"email"`
+	Email string `form:"email" json:"email"`
 
 	// in: formData
 	// required: true
 	// example: password1234
-	Password string `form:"password"`
+	Password string `form:"password" json:"password"`
 }
 
 // swagger:parameters board board-retrieve-one
@@ -51,7 +51,7 @@ type UpdateBoardRequest struct {
 	// Title of board
 	//
 	// in: body
-	Title string `form:"title"`
+	Title string `form:"title" json:"title"`
 }
 
 // swagger:parameters board board-delete
@@ -67,19 +67,13 @@ type DeleteBoardRequest struct {
 type GetColumnsRequest struct {
 	// UUID of parent board
 	//
-	// in: path
+	// in: query
 	// required: true
-	Board_GID string `param:"board_gid"`
+	Board_GID string `query:"board_gid"`
 }
 
 // swagger:parameters column column-retrieve-one
 type GetColumnRequest struct {
-	// UUID of parent board
-	//
-	// in: path
-	// required: true
-	Board_GID string `param:"board_gid"`
-
 	// UUID of column
 	//
 	// in: path
@@ -91,9 +85,9 @@ type GetColumnRequest struct {
 type UpdateColumnRequest struct {
 	// UUID of parent board
 	//
-	// in: path
+	// in: body
 	// required: true
-	Board_GID string `param:"board_gid"`
+	Board_GID string `form:"board_gid" json:"board_gid"`
 
 	// UUID of column
 	//
@@ -104,17 +98,11 @@ type UpdateColumnRequest struct {
 	// Title of column
 	//
 	// in: body
-	Title string `form:"title"`
+	Title string `form:"title" json:"title"`
 }
 
 // swagger:parameters column column-delete
 type DeleteColumnRequest struct {
-	// UUID of parent board
-	//
-	// in: path
-	// required: true
-	Board_GID string `param:"board_gid"`
-
 	// UUID of column
 	//
 	// in: path
@@ -126,19 +114,13 @@ type DeleteColumnRequest struct {
 type GetTasksRequest struct {
 	// UUID of parent column
 	//
-	// in: path
+	// in: query
 	// required: true
-	Column_GID string `param:"column_gid"`
+	Column_GID string `query:"column_gid"`
 }
 
 // swagger:parameters task task-retrieve-one
 type GetTaskRequest struct {
-	// UUID of parent column
-	//
-	// in: path
-	// required: true
-	Column_GID string `param:"column_gid"`
-
 	// UUID of task
 	//
 	// in: path
@@ -150,9 +132,9 @@ type GetTaskRequest struct {
 type UpdateTaskRequest struct {
 	// UUID of parent column
 	//
-	// in: path
+	// in: body
 	// required: true
-	Column_GID string `param:"column_gid"`
+	Column_GID string `form:"column_gid" json:"column_gid"`
 
 	// UUID of task
 	//
@@ -163,22 +145,16 @@ type UpdateTaskRequest struct {
 	// Title of task
 	//
 	// in: body
-	Title string `form:"title"`
+	Title string `form:"title" json:"title"`
 
 	// Description of task
 	//
 	// in: body
-	Description string `form:"description"`
+	Description string `form:"description" json:"description"`
 }
 
 // swagger:parameters task task-delete
 type DeleteTaskRequest struct {
-	// UUID of parent column
-	//
-	// in: path
-	// required: true
-	Column_GID string `param:"column_gid"`
-
 	// UUID of task
 	//
 	// in: path

--- a/server/routes/board.go
+++ b/server/routes/board.go
@@ -14,7 +14,7 @@ import (
 	"github.com/labstack/gommon/log"
 )
 
-// swagger:route GET /api/board board board-retrieve-all
+// swagger:route GET /api/r/board board board-retrieve-all
 //
 // Retrieves all boards
 //
@@ -42,7 +42,7 @@ func GetBoards(c echo.Context, log *log.Logger) error {
 	return c.JSON(http.StatusOK, boards)
 }
 
-// swagger:route GET /api/board/{Board_GID} board board-retrieve-one
+// swagger:route GET /api/r/board/{Board_GID} board board-retrieve-one
 //
 // Retrieves board by UUID
 //
@@ -87,7 +87,7 @@ func GetBoardById(c echo.Context, log *log.Logger) error {
 	return c.JSON(http.StatusOK, board)
 }
 
-// swagger:route PUT /api/board/{Board_GID} board board-update
+// swagger:route PUT /api/r/board/{Board_GID} board board-update
 //
 // Updates board by UUID
 //
@@ -133,7 +133,7 @@ func EditBoard(c echo.Context, log *log.Logger) error {
 	return c.JSON(http.StatusOK, board)
 }
 
-// swagger:route POST /api/board board board-create
+// swagger:route POST /api/r/board board board-create
 //
 // Creates a board
 //
@@ -167,7 +167,7 @@ func CreateBoard(c echo.Context, log *log.Logger) error {
 	return c.JSON(http.StatusCreated, board)
 }
 
-// swagger:route DELETE /api/board/{Board_GID} board board-delete
+// swagger:route DELETE /api/r/board/{Board_GID} board board-delete
 //
 // Deletes board by UUID
 //

--- a/server/server.go
+++ b/server/server.go
@@ -38,63 +38,33 @@ func main() {
 		return routes.LoginMember(c, logger)
 	})
 
+	// Authenticated Paths
+	r := e.Group("/api/r")
+	r.Use(middleware.JWTWithConfig(middleware.JWTConfig{
+		SigningKey: []byte(os.Getenv("JWT_SECRET")),
+	}))
+
 	// Board Routes
-	e.GET("/api/board", func(c echo.Context) error {
-		return routes.GetBoards(c, logger)
-	}, authenticated())
-	e.GET("/api/board/:board_gid", func(c echo.Context) error {
-		return routes.GetBoardById(c, logger)
-	}, authenticated())
-	e.PUT("/api/board/:board_gid", func(c echo.Context) error {
-		return routes.EditBoard(c, logger)
-	}, authenticated())
-	e.POST("/api/board", func(c echo.Context) error {
-		return routes.CreateBoard(c, logger)
-	}, authenticated())
-	e.DELETE("/api/board/:board_gid", func(c echo.Context) error {
-		return routes.DeleteBoard(c, logger)
-	}, authenticated())
+	r.GET("/board", func(c echo.Context) error { return routes.GetBoards(c, logger) })
+	r.GET("/board/:board_gid", func(c echo.Context) error { return routes.GetBoardById(c, logger) })
+	r.PUT("/board/:board_gid", func(c echo.Context) error { return routes.EditBoard(c, logger) })
+	r.POST("/board", func(c echo.Context) error { return routes.CreateBoard(c, logger) })
+	r.DELETE("/board/:board_gid", func(c echo.Context) error { return routes.DeleteBoard(c, logger) })
 
 	// Task Column Routes
-	e.GET("/api/column/:board_gid", func(c echo.Context) error {
-		return routes.GetColumns(c, logger)
-	}, authenticated())
-	e.GET("/api/column/:board_gid/:column_gid", func(c echo.Context) error {
-		return routes.GetColumnById(c, logger)
-	}, authenticated())
-	e.PUT("/api/column/:board_gid/:column_gid", func(c echo.Context) error {
-		return routes.EditColumn(c, logger)
-	}, authenticated())
-	e.POST("/api/column/:board_gid", func(c echo.Context) error {
-		return routes.CreateColumn(c, logger)
-	}, authenticated())
-	e.DELETE("/api/column/:board_gid/:column_gid", func(c echo.Context) error {
-		return routes.DeleteColumn(c, logger)
-	}, authenticated())
+	r.GET("/column", func(c echo.Context) error { return routes.GetColumns(c, logger) })
+	r.GET("/column/:column_gid", func(c echo.Context) error { return routes.GetColumnById(c, logger) })
+	r.PUT("/column/:column_gid", func(c echo.Context) error { return routes.EditColumn(c, logger) })
+	r.POST("/column", func(c echo.Context) error { return routes.CreateColumn(c, logger) })
+	r.DELETE("/column/:column_gid", func(c echo.Context) error { return routes.DeleteColumn(c, logger) })
 
 	// Task Routes
-	e.GET("/api/task/:column_gid", func(c echo.Context) error {
-		return routes.GetTasks(c, logger)
-	}, authenticated())
-	e.GET("/api/task/:column_gid/:task_gid", func(c echo.Context) error {
-		return routes.GetTaskById(c, logger)
-	}, authenticated())
-	e.PUT("/api/task/:column_gid/:task_gid", func(c echo.Context) error {
-		return routes.EditTask(c, logger)
-	}, authenticated())
-	e.POST("/api/task/:column_gid", func(c echo.Context) error {
-		return routes.CreateTask(c, logger)
-	}, authenticated())
-	e.DELETE("/api/task/:column_gid/:task_gid", func(c echo.Context) error {
-		return routes.DeleteTask(c, logger)
-	}, authenticated())
+	r.GET("/task", func(c echo.Context) error { return routes.GetTasks(c, logger) })
+	r.GET("/task/:task_gid", func(c echo.Context) error { return routes.GetTaskById(c, logger) })
+	r.PUT("/task/:task_gid", func(c echo.Context) error { return routes.EditTask(c, logger) })
+	r.POST("/task", func(c echo.Context) error { return routes.CreateTask(c, logger) })
+	r.DELETE("/task/:task_gid", func(c echo.Context) error { return routes.DeleteTask(c, logger) })
 
 	// Start server
 	e.Logger.Fatal(e.Start(":1323"))
-}
-
-func authenticated() echo.MiddlewareFunc {
-	return middleware.JWTWithConfig(middleware.JWTConfig{
-		SigningKey: []byte(os.Getenv("JWT_SECRET")),
-	})
 }

--- a/src/components/Column.jsx
+++ b/src/components/Column.jsx
@@ -41,10 +41,11 @@ class Column extends React.Component {
         const { gid, title, tasks, updateColumn } = this.props;
 
         const formdata = new FormData();
+        formdata.append('column_gid', gid);
         formdata.append('title', '');
         formdata.append('description', '');
 
-        createTask(gid, formdata).then((data) => {
+        createTask(formdata).then((data) => {
             updateColumn({
                 gid,
                 title,
@@ -88,11 +89,12 @@ class Column extends React.Component {
             clearTimeout(taskTimers[task.gid]);
 
             const formdata = new FormData();
+            formdata.append('column_gid', gid);
             formdata.append('title', task.title);
             formdata.append('description', task.description);
 
             taskTimers[task.gid] = setTimeout(
-                () => updateTask(gid, task.gid, formdata),
+                () => updateTask(task.gid, formdata),
                 500
             );
 

--- a/src/components/LoginRegisterCard.jsx
+++ b/src/components/LoginRegisterCard.jsx
@@ -22,7 +22,7 @@ function LoginForm({ setError }) {
         formdata.append('remember', remember);
 
         axios
-            .post(`${config.API_URL}/login`, formdata, {
+            .post(`${config.UNAUTH_API_URL}/login`, formdata, {
                 headers: { 'Content-Type': 'multipart/form-data' },
             })
             .then((response) => {
@@ -105,7 +105,7 @@ function RegisterForm({ setError }) {
         formdata.append('password', password);
 
         axios
-            .post(`${config.API_URL}/register`, formdata, {
+            .post(`${config.UNAUTH_API_URL}/register`, formdata, {
                 headers: { 'Content-Type': 'multipart/form-data' },
             })
             .then((response) => {

--- a/src/config.json
+++ b/src/config.json
@@ -1,3 +1,4 @@
 {
-    "API_URL": "http://127.0.0.1:1323/api"
+    "API_URL": "http://127.0.0.1:1323/api/r",
+    "UNAUTH_API_URL": "http://127.0.0.1:1323/api"
 }

--- a/src/pages/ViewBoard.jsx
+++ b/src/pages/ViewBoard.jsx
@@ -117,6 +117,7 @@ export default class ViewBoard extends React.Component {
         retrieveBoard(boardGid)
             .then(({ data }) => this.setState({ title: data.title }))
             .catch(() => window.location.replace('/board'));
+
         retrieveColumns(boardGid).then(({ data }) => {
             const columns = data;
             columns.forEach(async (column, index, arr) => {
@@ -169,10 +170,11 @@ export default class ViewBoard extends React.Component {
             task.task_column_id = dColumn.id;
 
             const formdata = new FormData();
+            formdata.append('column_gid', dColumn.gid);
             formdata.append('title', task.title || '');
             formdata.append('description', task.description || '');
 
-            updateTask(dColumn.gid, taskGid, formdata).then(() => {
+            updateTask(taskGid, formdata).then(() => {
                 this.updateColumnUI({
                     gid: sColumn.gid,
                     title: sColumn.title,
@@ -191,9 +193,10 @@ export default class ViewBoard extends React.Component {
         const { gid } = this.state;
 
         const formdata = new FormData();
+        formdata.append('board_gid', gid);
         formdata.append('title', '');
 
-        createColumn(gid, formdata).then(({ data }) => {
+        createColumn(formdata).then(({ data }) => {
             const { columns } = this.state;
             this.setState({ columns: columns.concat([data]) });
         });
@@ -225,10 +228,11 @@ export default class ViewBoard extends React.Component {
             clearTimeout(columnTimers[column.gid]);
 
             const formdata = new FormData();
+            formdata.append('board_gid', gid);
             formdata.append('title', column.title);
 
             columnTimers[column.gid] = setTimeout(
-                () => updateColumn(gid, column.gid, formdata),
+                () => updateColumn(column.gid, formdata),
                 500
             );
 
@@ -239,11 +243,7 @@ export default class ViewBoard extends React.Component {
     };
 
     handleColumnRemove = (column) => {
-        const { gid } = this.state;
-
-        deleteColumn(gid, column.gid).then(() => {
-            this.removeColumn(column.gid);
-        });
+        deleteColumn(column.gid).then(() => this.removeColumn(column.gid));
     };
 
     getColumn = (gid) => {

--- a/src/util/board_functions.js
+++ b/src/util/board_functions.js
@@ -46,25 +46,16 @@ function deleteBoard(bGid) {
     });
 }
 
-function retrieveColumns(gid) {
-    return axios.get(`${config.API_URL}/column/${gid}`, {
+function retrieveColumns(bGid) {
+    return axios.get(`${config.API_URL}/column?board_gid=${bGid}`, {
         headers: {
             Authorization: `Bearer ${JWT}`,
         },
     });
 }
 
-function updateColumn(bGid, cGid, formdata) {
-    return axios.put(`${config.API_URL}/column/${bGid}/${cGid}`, formdata, {
-        headers: {
-            'Content-Type': 'multipart/form-data',
-            Authorization: `Bearer ${JWT}`,
-        },
-    });
-}
-
-function createColumn(cGid, formdata) {
-    return axios.post(`${config.API_URL}/column/${cGid}`, formdata, {
+function updateColumn(cGid, formdata) {
+    return axios.put(`${config.API_URL}/column/${cGid}`, formdata, {
         headers: {
             'Content-Type': 'multipart/form-data',
             Authorization: `Bearer ${JWT}`,
@@ -72,8 +63,17 @@ function createColumn(cGid, formdata) {
     });
 }
 
-function deleteColumn(bGid, cGid) {
-    return axios.delete(`${config.API_URL}/column/${bGid}/${cGid}`, {
+function createColumn(formdata) {
+    return axios.post(`${config.API_URL}/column`, formdata, {
+        headers: {
+            'Content-Type': 'multipart/form-data',
+            Authorization: `Bearer ${JWT}`,
+        },
+    });
+}
+
+function deleteColumn(cGid) {
+    return axios.delete(`${config.API_URL}/column/${cGid}`, {
         headers: {
             'Content-Type': 'multipart/form-data',
             Authorization: `Bearer ${JWT}`,
@@ -82,24 +82,15 @@ function deleteColumn(bGid, cGid) {
 }
 
 function retrieveTasks(cGid) {
-    return axios.get(`${config.API_URL}/task/${cGid}`, {
+    return axios.get(`${config.API_URL}/task?column_gid=${cGid}`, {
         headers: {
             Authorization: `Bearer ${JWT}`,
         },
     });
 }
 
-function updateTask(cGid, tGid, formdata) {
-    return axios.put(`${config.API_URL}/task/${cGid}/${tGid}`, formdata, {
-        headers: {
-            'Content-Type': 'multipart/form-data',
-            Authorization: `Bearer ${JWT}`,
-        },
-    });
-}
-
-function createTask(cGid, formdata) {
-    return axios.post(`${config.API_URL}/task/${cGid}`, formdata, {
+function updateTask(tGid, formdata) {
+    return axios.put(`${config.API_URL}/task/${tGid}`, formdata, {
         headers: {
             'Content-Type': 'multipart/form-data',
             Authorization: `Bearer ${JWT}`,
@@ -107,8 +98,17 @@ function createTask(cGid, formdata) {
     });
 }
 
-function deleteTask(cGid, tGid) {
-    return axios.delete(`${config.API_URL}/task/${cGid}/${tGid}`, {
+function createTask(formdata) {
+    return axios.post(`${config.API_URL}/task`, formdata, {
+        headers: {
+            'Content-Type': 'multipart/form-data',
+            Authorization: `Bearer ${JWT}`,
+        },
+    });
+}
+
+function deleteTask(tGid) {
+    return axios.delete(`${config.API_URL}/task/${tGid}`, {
         headers: {
             'Content-Type': 'multipart/form-data',
             Authorization: `Bearer ${JWT}`,


### PR DESCRIPTION
**Description**
Updates the structure of paths in the API and the accompanying calls in the UI.

**Tasks**
- [x] Group authenticated APIs and apply middleware once
- [x] Remove parent UUIDs from API paths (eg. `/api/task/<column_gid>/<task_gid>` to `/api/task/<task_gid>`)
  - [x] Re-add as query or body parameters as necessary
  - [x] Add permissions check helper for task API
- [x] Update associated documentation and regenerate swagger.yml
- [x] Update API calls in the UI to point to new paths and use correct bodies
